### PR TITLE
css changes to address host switcher

### DIFF
--- a/pkg/shell/base_index.js
+++ b/pkg/shell/base_index.js
@@ -600,20 +600,20 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
         }
 
         self.recalculate_layout = function() {
-            var topnav = $('#topnav');
-            var sidebar = $('#host-nav');
-            var main_nav = $(".multi-dashboard");
-            var content = $('#content');
+            // var topnav = $('#topnav');
+            // var sidebar = $('#host-nav');
+            // var main_nav = $(".multi-dashboard");
+            // var content = $('#content');
 
-            var window_height = $(window).height();
-            var topnav_height = topnav.height();
+            // var window_height = $(window).height();
+            // var topnav_height = topnav.height();
 
-            var y = window_height - topnav_height;
-            $(current_frame).height(Math.floor(y));
+            // var y = window_height - topnav_height;
+            // $(current_frame).height(Math.floor(y));
 
-            var sidebar_width = sidebar.is(':visible') ? sidebar.outerWidth() : 0;
-            sidebar_width += main_nav.is(':visible') ? main_nav.outerWidth() : 0;
-            content.css("margin-left", sidebar_width + "px");
+            // var sidebar_width = sidebar.is(':visible') ? sidebar.outerWidth() : 0;
+            // sidebar_width += main_nav.is(':visible') ? main_nav.outerWidth() : 0;
+            // content.css("margin-left", sidebar_width + "px");
         };
 
         self.retrieve_state = function() {

--- a/pkg/shell/base_index.js
+++ b/pkg/shell/base_index.js
@@ -599,23 +599,6 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
             navbar.append(local_compiled.ordered("dashboard").map(links));
         }
 
-        self.recalculate_layout = function() {
-            // var topnav = $('#topnav');
-            // var sidebar = $('#host-nav');
-            // var main_nav = $(".multi-dashboard");
-            // var content = $('#content');
-
-            // var window_height = $(window).height();
-            // var topnav_height = topnav.height();
-
-            // var y = window_height - topnav_height;
-            // $(current_frame).height(Math.floor(y));
-
-            // var sidebar_width = sidebar.is(':visible') ? sidebar.outerWidth() : 0;
-            // sidebar_width += main_nav.is(':visible') ? main_nav.outerWidth() : 0;
-            // content.css("margin-left", sidebar_width + "px");
-        };
-
         self.retrieve_state = function() {
             var state = window.history.state;
             if (!state || state.version !== "v1") {

--- a/pkg/shell/indexes.js
+++ b/pkg/shell/indexes.js
@@ -168,8 +168,6 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
             update_navbar(machine, state, compiled);
             update_frame(machine, state, compiled);
 
-            index.recalculate_layout();
-
             /* Just replace the state, and URL */
             index.jump(state, true);
         }
@@ -540,8 +538,6 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
             }
             update_navbar(state);
             update_frame(state);
-
-            index.recalculate_layout();
 
             /* Just replace the state, and URL */
             index.jump(state, true);

--- a/pkg/shell/switcher.less
+++ b/pkg/shell/switcher.less
@@ -3,6 +3,7 @@
 }
 
 .flex-navbar {
+    flex: none;
     min-width: 100%;
 }
 
@@ -15,17 +16,20 @@
 
 .flex-sidebar {
     position: relative;
-}
-
-.flex-sidebar {
     flex: none;
     z-index: 999;
+    display: flex;
 }
 
 .nav-pf-vertical {
     position: static !important;
     height: 100%;
     border-right-width: 0;
+    top: 0;
+}
+
+.nav-sidebar {
+    position: relative;
 }
 
 .nav-sidebar-wrap:not(.expanded) {
@@ -74,7 +78,7 @@
 }
 
 .nav-sidebar {
-    height: 100vh;
+    // height: 100vh;
 }
 
 .nav-sidebar-wrap:not(.expanded) .nav-sidebar:not(.clicked):hover {
@@ -106,24 +110,25 @@
 }
 
 .nav-pf-secondary-nav {
-    left: unit(@sidebar-width-sm, px);
+    // left: unit(@sidebar-width-sm, px);
     background: #393f44;
     border-right: 1px solid #292e34;
     border-bottom: none;
     border-top: none;
     border-left: none;
-    bottom: 0;
-    overflow-x: hidden;
-    overflow-y: auto;
-    position: fixed;
-    top: 49px;
-    width: 200px;
+    flex: auto;
+    // bottom: 0;
+    // overflow-x: hidden;
+    // overflow-y: auto;
+    // position: fixed;
+    // top: 49px;
+    // width: 200px;
     z-index: -1;
 }
 
 .nav-item-pf-header {
-	color: #fff;
-	font-size: 16px;
+    color: #fff;
+    font-size: 16px;
     margin: 18px 20px 10px 20px;
 }
 
@@ -151,6 +156,7 @@
     overflow: visible;
     display: flex;
     flex-direction: column;
+    min-width: 15em;
 }
 
 #host-nav-item {
@@ -163,9 +169,10 @@
 
 .flex-container {
     display: flex;
-    width: 100%;
-    height: 100%;
+    width: 100vw;
+    height: 100vh;
     flex-flow: row wrap;
+    align-content: start;
 }
 
 .flex-content {
@@ -177,6 +184,6 @@
 }
 
 #host-apps {
-    flex: auto;
+    flex: 1 1 0;
     overflow-y: auto;
 }


### PR DESCRIPTION
This makes the menu items scrollable for the host sidebar (and the host dropdown stay in place) so the host switcher dropdown doesn't mess with the overflow.

An alternative approach would be to move the dropdown out of the overflowing secondary nav menu, but this seemed less invasive. The biggest side effect of this approach is that host switching is not affected by the scrolling area of the secondary sidebar. It's debatable if this is a good or bad change. (The advantage of this method is that you always know which host you're viewing and can easily switch to another. The biggest drawback is that there's now less room for menu items when scrolling. In the cases scrolling isn't needed, then this change shouldn't affect much.)

I made the patches in such a way that the secondary sidebar still scrolls in other contexts — this should only affect the host version of the sidebar.