### PR TITLE
support single-nav

### DIFF
--- a/containers/kubernetes/registry-dashboard-override.json
+++ b/containers/kubernetes/registry-dashboard-override.json
@@ -3,7 +3,8 @@
     "dashboard": {
         "index": {
             "label": "Image Registry",
-            "order": -1
+            "order": -1,
+            "icon": "pficon-registry""
         }
     }
 }

--- a/pkg/dashboard/manifest.json.in
+++ b/pkg/dashboard/manifest.json.in
@@ -8,7 +8,8 @@
         "index": {
             "label": "Dashboard",
             "order": 10,
-            "wants": "multiple-machines"
+            "wants": "multiple-machines",
+            "icon": "pficon-topology"
         }
     }
 }

--- a/pkg/kubernetes/index.html
+++ b/pkg/kubernetes/index.html
@@ -32,7 +32,10 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 <body ng-app='kubernetes' ng-controller="MainCtrl" ng-class="{'cards-pf': viewActive(null)}" hidden>
     <div ng-cloak ng-if="!curtains">
-        <div class="nav-pf-vertical nav-sidebar">
+        <div class="nav-pf-vertical nav-pf-secondary-nav nav-sidebar">
+            <div class="nav-item-pf-header">
+                <span translate>Cluster</span>
+            </div>
             <ul class="list-group">
                 <li class="list-group-item" ng-class="{ active: viewActive(null)}">
                     <a ng-href="#{{ viewUrl(null) }}">

--- a/pkg/kubernetes/manifest.json.in
+++ b/pkg/kubernetes/manifest.json.in
@@ -7,7 +7,8 @@
     "dashboard": {
         "index": {
             "label": "Cluster",
-            "order": 20
+            "order": 20,
+            "icon": "pficon-cluster"
         }
     }
 }

--- a/pkg/kubernetes/override.json
+++ b/pkg/kubernetes/override.json
@@ -2,7 +2,8 @@
     "dashboard": {
         "registry": {
             "label": "Image Registry",
-            "order": 30
+            "order": 30,
+            "icon": "pficon-registry""
         }
     }
 }

--- a/pkg/kubernetes/registry.html
+++ b/pkg/kubernetes/registry.html
@@ -36,6 +36,9 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 <body ng-app='registry' ng-controller="MainCtrl" ng-class="{'cards-pf': viewActive(null)}" hidden>
     <div ng-cloak ng-if="!curtains">
         <div class="icon-sidebar">
+            <div class="nav-item-pf-header">
+                <span translate>Image Registry</span>
+            </div>
             <ul>
                 <li ng-class="{ active: viewActive(null)}">
                     <a ng-href="#{{ viewUrl(null) }}">

--- a/pkg/kubernetes/styles/registry.less
+++ b/pkg/kubernetes/styles/registry.less
@@ -164,6 +164,12 @@
 .icon-sidebar {
     width: unit(@icon-sidebar-width, px);
 
+    .nav-item-pf-header {
+	    color: #fff;
+	    font-size: 16px;
+        margin: 18px 20px 10px 20px;
+    }
+
     ul {
         margin: 0;
         padding: 0;
@@ -171,19 +177,19 @@
         width: unit(@icon-sidebar-width - 10, px);
         height: 100%;
         position: fixed;
-        background-color: @nav-pf-vertical-bg-color;
+        background-color: @nav-pf-vertical-secondary-bg-color;
         top: 0px;
         z-index: 1;
 
         li {
-            border-bottom: 1px solid @nav-pf-vertical-item-border-color;
+            border-bottom: 1px solid @nav-pf-vertical-border-color;
             display: block;
             font-size: 13px;
 
             a {
                 border-bottom: 0;
-                color: @nav-pf-vertical-color;
-                background-color: @nav-pf-vertical-bg-color;
+                color: @nav-pf-vertical-secondary-color;
+                background-color: @nav-pf-vertical-secondary-bg-color;
                 padding: 15px 11px 15px 9px;
                 text-align: center;
                 display: block;
@@ -204,8 +210,8 @@
             }
 
             a:hover {
-                color: @nav-pf-vertical-active-color;
-                background-color: @nav-pf-vertical-active-bg-color;
+                color: @nav-pf-vertical-secondary-active-color;
+                background-color: @nav-pf-vertical-secondary-active-bg-color;
 
                 i {
                     color: @nav-pf-vertical-active-icon-color;
@@ -215,8 +221,8 @@
 
         li.active {
             a  {
-                color: @nav-pf-vertical-active-color;
-                background-color: @nav-pf-vertical-active-bg-color;
+                color: @nav-pf-vertical-secondary-active-color;
+                background-color: @nav-pf-vertical-secondary-active-bg-color;
 
 		i {
 			color: @link-color;

--- a/pkg/kubernetes/styles/sidebar.less
+++ b/pkg/kubernetes/styles/sidebar.less
@@ -1,6 +1,12 @@
 /*
  * Full large size sidebar.
  */
+
+
+.nav-pf-secondary-nav {
+    background: #393f44;
+}
+
 .nav-sidebar {
     width: unit(@sidebar-width-xl, px);
     height: 100%;
@@ -8,7 +14,13 @@
     top: 0px;
     z-index: 1;
     overflow-x: hidden;
-    overflow-y: hidden;
+    overflow-y: auto;
+
+    border-right: 1px solid #292e34;
+    border-bottom: none;
+    border-top: none;
+    border-left: none;
+    bottom: 0;
 
     a {
         width: unit(@sidebar-width-xl, px) !important;
@@ -16,6 +28,33 @@
     .list-group-item-value {
         max-width: unit(@sidebar-width-xl - 80, px) !important;
     }
+}
+
+.nav-item-pf-header {
+	color: #fff;
+	font-size: 16px;
+    margin: 18px 20px 10px 20px;
+}
+
+.nav-pf-secondary-nav .list-group {
+    border: none;
+}
+
+.nav-pf-secondary-nav .list-group-item {
+    background: inherit;
+    border: none;
+}
+
+.nav-pf-secondary-nav .list-group-item.active {
+    background-color: #4d5258;
+}
+.nav-pf-secondary-nav > .list-group > .list-group-item.active > a {
+    background-color: inherit;
+}
+
+.nav-pf-secondary-nav .list-group-item a {
+    display: block;
+    color: #d1d1d1;
 }
 
 #content {

--- a/pkg/shell/base_index.js
+++ b/pkg/shell/base_index.js
@@ -560,29 +560,49 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
         }
 
         function build_navbar() {
-            var navbar = $("#content-navbar");
+            var navbar = $("#main-navbar");
+            navbar.on("click", function () {
+                navbar.parent().toggleClass("clicked", true);
+            });
+
+            navbar.on("mouseout", function () {
+                navbar.parent().toggleClass("clicked", false);
+            });
 
             function links(component) {
+                var sm = $("<span class='fa'>")
+                    .attr("data-toggle", "tooltip")
+                    .attr("title", "")
+                    .attr("data-original-title", component.label);
+
+                if (component.icon)
+                    sm.addClass(component.icon);
+                else
+                    sm.addClass("first-letter").text(component.label);
+
+                var value = $("<span class='list-group-item-value'>")
+                    .text(component.label);
+
                 var a = $("<a>")
                     .attr("href", self.href({ host: "localhost", component: component.path }))
-                    .text(component.label);
-                return $("<li class='dashboard-link'>")
+                    .attr("title", component.label)
+                    .append(sm)
+                    .append(value);
+
+                return $("<li class='dashboard-link list-group-item'>")
                     .attr("data-component", component.path)
                     .append(a);
             }
 
-            if (shell_embedded) {
-                navbar.hide();
-            } else {
-                var local_compiled = new CompiledComponents();
-                local_compiled.load(cockpit.manifests, "dashboard");
-                navbar.append(local_compiled.ordered("dashboard").map(links));
-            }
+            var local_compiled = new CompiledComponents();
+            local_compiled.load(cockpit.manifests, "dashboard");
+            navbar.append(local_compiled.ordered("dashboard").map(links));
         }
 
         self.recalculate_layout = function() {
             var topnav = $('#topnav');
-            var sidebar = $('#sidebar');
+            var sidebar = $('#host-nav');
+            var main_nav = $(".multi-dashboard");
             var content = $('#content');
 
             var window_height = $(window).height();
@@ -590,9 +610,9 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
 
             var y = window_height - topnav_height;
             $(current_frame).height(Math.floor(y));
-            sidebar.height(y);
 
             var sidebar_width = sidebar.is(':visible') ? sidebar.outerWidth() : 0;
+            sidebar_width += main_nav.is(':visible') ? main_nav.outerWidth() : 0;
             content.css("margin-left", sidebar_width + "px");
         };
 
@@ -863,6 +883,7 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
                         section: section,
                         label: cockpit.gettext(info.label) || prop,
                         order: info.order === undefined ? 1000 : info.order,
+                        icon: info.icon,
                         wants: info.wants
                     };
                     if (info.path)

--- a/pkg/shell/index-stub.js
+++ b/pkg/shell/index-stub.js
@@ -41,6 +41,15 @@
         about_sel: "#about-version",
         default_title: default_title
     };
+
+    /* When alt is held down we display debugging menu items */
+    document.addEventListener("click", function(ev) {
+        var i, visible = !!ev.altKey;
+        var advanced = document.querySelectorAll(".navbar-advanced");
+        for (i = 0; i < advanced.length; i++)
+            advanced[i].style.display = visible ? "block" : "none";
+    }, true);
+
     var machines = machis.instance();
     machines.overlay("localhost", { "label": default_title,
                                     "static_hostname": true });

--- a/pkg/shell/index.html
+++ b/pkg/shell/index.html
@@ -13,316 +13,342 @@
     <script src="../*/po.js"></script>
   </head>
   <body hidden>
-    <nav id="topnav" class="navbar navbar-default navbar-pf" role="navigation">
-      <div class="navbar-header">
-        <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse-1">
-          <i class="fa fa-bars" alt="Toggle navigation"></i>
-        </button>
-        <div class="navbar-brand">
-          <div id="index-brand"></div>
-        </div>
-      </div>
-      <div class="collapse navbar-collapse navbar-collapse-1">
-        <ul class="nav navbar-nav navbar-utility">
-          <li class="credential-lock">
-            <a data-toggle="tooltip" data-placement="bottom" translate="title"
-                title="Privileged tasks not available">
-              <i class="fa fa-lock"></i>
-              <span translate>Locked</span>
-            </a>
-            <a data-toggle="tooltip" data-placement="bottom" translate="title"
-                title="Lock to prevent privileged tasks" class="credential-clear">
-              <i class="fa fa-unlock-alt"></i>
-              <span translate>Unlocked</span>
-            </a>
-          </li>
-          <li id="navbar-oops" hidden>
-            <a><span class="oops-status" translatable="yes">Ooops!</span></a>
-          </li>
-          <li class="dropdown">
-            <a id="navbar-dropdown" class="dropdown-toggle" data-toggle="dropdown">
-              <span class="pficon pficon-user"></span>
-              <span id="content-user-name"></span><b class="caret"></b>
-            </a>
-            <ul class="dropdown-menu">
-              <li class="display-language-menu">
-                <a data-toggle="modal" data-target="#display-language" translatable="yes">Display Language</a>
-              </li>
-              <li class="divider display-language-menu"></li>
-              <li>
-                <a data-toggle="modal" data-target="#about" translatable="yes">About Cockpit</a>
-              </li>
-              <li>
-                <a id="active-pages" translatable="yes" class="navbar-advanced">Active Pages</a>
-              </li>
-              <li class="divider"></li>
-              <li id="go-account" hidden>
-                <a translatable="yes">Account Settings</a>
-              </li>
-              <li>
-                  <a data-toggle="modal" data-target="#credentials-dialog"
-                      id="credentials-item" translatable="yes">Authentication</a>
-              </li>
-              <li>
-                <a id="go-logout" translatable="yes">Log Out</a>
-              </li>
-            </ul>
-          </li>
-        </ul>
-        <ul class="nav navbar-nav navbar-primary" id="content-navbar">
-          <li id="machine-spinner" hidden>
-            <div class="spinner spinner-md spinner-white">
-            </div>
-          </li>
-          <li class="dropdown" id="machine-dropdown">
-            <a class="machine-color"></a>
-            <a id="machine-link" class="dropdown-toggle" data-toggle="dropdown"
-                aria-haspopup="true" role="button" aria-expanded="false">
-               <img src="../shell/images/server-small.png" id="machine-avatar" class="machine-avatar"><span translate>Machines</span>
-               <b class="caret"></b>
-            </a>
-            <ul class="dropdown-menu" role="menu" aria-labelledby="machine-link">
-            </ul>
-          </li>
-        </ul>
-      </div>
-    </nav>
-
-    <div class="modal" id="about" tabindex="-1" role="dialog" data-backdrop="static">
-      <div class="modal-dialog">
-        <div class="modal-content">
-          <div class="modal-header">
-            <h4 class="modal-title" translatable="yes">About Cockpit</h4>
-          </div>
-          <div class="modal-body">
-            <div translatable="yes">Cockpit is an interactive Linux server admin interface.</div>
-            <div><a target="_blank" href="http://cockpit-project.org/" translate>Project website</a></div>
-            <div>
-              <span translatable="yes">Version</span> <span id="about-version"></span>.
-            </div>
-            <div><span translate>Licensed under:</span>
-                <a href="https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html"
-                  target="_blank">GNU LGPL version 2.1</a>
+    <div class="flex-container">
+        <nav id="topnav" class="navbar navbar-default navbar-pf navbar-pf-vertical flex-navbar" role="navigation">
+          <div class="navbar-header">
+            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse-1">
+              <i class="fa fa-bars" alt="Toggle navigation"></i>
+            </button>
+            <div class="navbar-brand">
+              <div id="index-brand"></div>
             </div>
           </div>
-          <div class="modal-footer">
-            <button class="btn btn-primary" data-dismiss="modal" translate>Close</button>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <div class="modal" id="troubleshoot-dialog" tabindex="-1" role="dialog"
-        data-backdrop="static">
-        <div class="modal-dialog">
-            <div class="modal-content">
-            </div>
-        </div>
-    </div>
-
-    <div class="modal" id="display-language" tabindex="-1" role="dialog" data-backdrop="static">
-      <div class="modal-dialog">
-        <div class="modal-content">
-          <div class="modal-header">
-            <h4 class="modal-title" translatable="yes">Display Language</h4>
-          </div>
-          <div class="modal-body">
-	    <p translatable="yes">Choose the language to be used in the application</p>
-            <select id="display-language-list" size="5" data-role="none">
-            </select>
-          </div>
-          <div class="modal-footer">
-            <button class="btn btn-default" data-dismiss="modal" translatable="yes">Cancel</button>
-            <button class="btn btn-primary" id="display-language-select-button" translatable="yes">Select</button>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <div class="modal" id="error-popup" tabindex="-1" role="dialog" data-backdrop="static">
-      <div class="modal-dialog">
-        <div class="modal-content">
-          <div class="modal-header">
-            <h4 class="modal-title" id="error-popup-title"></h4>
-          </div>
-          <div class="modal-body">
-            <p id="error-popup-message"></p>
-          </div>
-          <div class="modal-footer">
-            <button class="btn btn-primary" data-dismiss="modal" translatable="yes">Close</button>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <div class="modal" id="credentials-dialog" tabindex="-1" role="dialog" data-backdrop="static">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h4 class="modal-title" translatable="yes">Authentication</h4>
+          <div class="collapse navbar-collapse navbar-collapse-1">
+            <ul class="nav navbar-nav navbar-utility">
+              <li id="machine-spinner">
+                <div class="spinner spinner-md spinner-white">
                 </div>
-                <div class="modal-body modal-scrollable">
-                    <table class="listing-ct credential-listing">
-                        <thead class="credential-lock">
-                            <tr>
-                                <td translate colspan="2">Password not usable for privileged tasks or to connect to other machines</td>
-                                <td></td>
-                            </tr>
-                            <tr>
-                                <td translate colspan="2">Reuse my password for privileged tasks and to connect to other machines</td>
-                                <td class="listing-ct-actions">
-                                    <button class="btn btn-default pficon pficon-close credential-clear">
-                                    </button>
-                                </td>
-                            </tr>
-                        </thead>
-                        <thead>
-                            <tr id="credential-keys">
-                                <td translatable="yes" colspan="2">Use the following keys to authenticate against other systems</td>
-                                <td class="listing-ct-actions">
-                                </td>
-                            </tr>
-                        </thead>
-                        <tbody hidden>
-                            <tr class="listing-ct-item listing-ct-head">
-                                <th class="credential-label"></th>
-                                <td></td>
-                                <td class="listing-ct-actions">
-                                    <div class="btn-group btn-onoff-ct" data-toggle="buttons">
-                                        <label class="btn">
-                                            <input type="radio" autocomplete="off">
-                                            <span translatable="yes">On</span>
-                                        </label>
-                                        <label class="btn active">
-                                            <input type="radio" autocomplete="off" checked>
-                                            <span translatable="yes">Off</span>
-                                        </label>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr class="listing-ct-panel credential-panel">
-                                <td colspan="3">
-                                    <ul class="nav nav-tabs nav-tabs-pf">
-                                        <li class="active"><a href="#" translatable="yes">Details</a></li>
-                                        <li><a href="#" translatable="yes">Public Key</a></li>
-                                        <li><a href="#" translatable="yes">Password</a></li>
-                                    </ul>
-                                </td>
-                            </tr>
-                            <tr class="listing-ct-body">
-                                <td colspan="3">
-                                    <div class="alert alert-danger">
-                                        <i class="fa fa-exclamation-triangle"></i>
-                                        <span></span>
-                                    </div>
-                                    <div class="credential-unlock">
-                                        <dl>
-                                            <dt>
-                                                <label translatable="yes">Password</label>
-                                            </dt>
-                                            <dd>
-                                                <input class="form-control credential-password"
+              </li>
+              <li class="credential-lock">
+                <a data-toggle="tooltip" data-placement="bottom" translate="title"
+                    title="Privileged tasks not available">
+                  <i class="fa fa-lock"></i>
+                  <span translate>Locked</span>
+                </a>
+                <a data-toggle="tooltip" data-placement="bottom" translate="title"
+                    title="Lock to prevent privileged tasks" class="credential-clear">
+                  <i class="fa fa-unlock-alt"></i>
+                  <span translate>Unlocked</span>
+                </a>
+              </li>
+              <li id="navbar-oops" hidden>
+                <a><span class="oops-status" translatable="yes">Ooops!</span></a>
+              </li>
+              <li class="dropdown">
+                <a id="navbar-dropdown" class="dropdown-toggle" data-toggle="dropdown">
+                  <span class="pficon pficon-user"></span>
+                  <span id="content-user-name"></span><b class="caret"></b>
+                </a>
+                <ul class="dropdown-menu">
+                  <li class="display-language-menu">
+                    <a data-toggle="modal" data-target="#display-language" translatable="yes">Display Language</a>
+                  </li>
+                  <li class="divider display-language-menu"></li>
+                  <li>
+                    <a data-toggle="modal" data-target="#about" translatable="yes">About Cockpit</a>
+                  </li>
+                  <li>
+                    <a id="active-pages" translatable="yes" class="navbar-advanced">Active Pages</a>
+                  </li>
+                  <li class="divider"></li>
+                  <li id="go-account" hidden>
+                    <a translatable="yes">Account Settings</a>
+                  </li>
+                  <li>
+                      <a data-toggle="modal" data-target="#credentials-dialog"
+                          id="credentials-item" translatable="yes">Authentication</a>
+                  </li>
+                  <li>
+                    <a id="go-logout" translatable="yes">Log Out</a>
+                  </li>
+                </ul>
+              </li>
+            </ul>
+          </div>
+        </nav>
+
+        <div class="modal" id="about" tabindex="-1" role="dialog" data-backdrop="static">
+          <div class="modal-dialog">
+            <div class="modal-content">
+              <div class="modal-header">
+                <h4 class="modal-title" translatable="yes">About Cockpit</h4>
+              </div>
+              <div class="modal-body">
+                <div translatable="yes">Cockpit is an interactive Linux server admin interface.</div>
+                <div><a target="_blank" href="http://cockpit-project.org/" translate>Project website</a></div>
+                <div>
+                  <span translatable="yes">Version</span> <span id="about-version"></span>.
+                </div>
+                <div><span translate>Licensed under:</span>
+                    <a href="https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html"
+                      target="_blank">GNU LGPL version 2.1</a>
+                </div>
+              </div>
+              <div class="modal-footer">
+                <button class="btn btn-primary" data-dismiss="modal" translate>Close</button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="modal" id="troubleshoot-dialog" tabindex="-1" role="dialog"
+            data-backdrop="static">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                </div>
+            </div>
+        </div>
+
+        <div class="modal" id="display-language" tabindex="-1" role="dialog" data-backdrop="static">
+          <div class="modal-dialog">
+            <div class="modal-content">
+              <div class="modal-header">
+                <h4 class="modal-title" translatable="yes">Display Language</h4>
+              </div>
+              <div class="modal-body">
+	        <p translatable="yes">Choose the language to be used in the application</p>
+                <select id="display-language-list" size="5" data-role="none">
+                </select>
+              </div>
+              <div class="modal-footer">
+                <button class="btn btn-default" data-dismiss="modal" translatable="yes">Cancel</button>
+                <button class="btn btn-primary" id="display-language-select-button" translatable="yes">Select</button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="modal" id="error-popup" tabindex="-1" role="dialog" data-backdrop="static">
+          <div class="modal-dialog">
+            <div class="modal-content">
+              <div class="modal-header">
+                <h4 class="modal-title" id="error-popup-title"></h4>
+              </div>
+              <div class="modal-body">
+                <p id="error-popup-message"></p>
+              </div>
+              <div class="modal-footer">
+                <button class="btn btn-primary" data-dismiss="modal" translatable="yes">Close</button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="modal" id="credentials-dialog" tabindex="-1" role="dialog" data-backdrop="static">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h4 class="modal-title" translatable="yes">Authentication</h4>
+                    </div>
+                    <div class="modal-body modal-scrollable">
+                        <table class="listing-ct credential-listing">
+                            <thead class="credential-lock">
+                                <tr>
+                                    <td translate colspan="2">Password not usable for privileged tasks or to connect to other machines</td>
+                                    <td></td>
+                                </tr>
+                                <tr>
+                                    <td translate colspan="2">Reuse my password for privileged tasks and to connect to other machines</td>
+                                    <td class="listing-ct-actions">
+                                        <button class="btn btn-default pficon pficon-close credential-clear">
+                                        </button>
+                                    </td>
+                                </tr>
+                            </thead>
+                            <thead>
+                                <tr id="credential-keys">
+                                    <td translatable="yes" colspan="2">Use the following keys to authenticate against other systems</td>
+                                    <td class="listing-ct-actions">
+                                    </td>
+                                </tr>
+                            </thead>
+                            <tbody hidden>
+                                <tr class="listing-ct-item listing-ct-head">
+                                    <th class="credential-label"></th>
+                                    <td></td>
+                                    <td class="listing-ct-actions">
+                                        <div class="btn-group btn-onoff-ct" data-toggle="buttons">
+                                            <label class="btn">
+                                                <input type="radio" autocomplete="off">
+                                                <span translatable="yes">On</span>
+                                            </label>
+                                            <label class="btn active">
+                                                <input type="radio" autocomplete="off" checked>
+                                                <span translatable="yes">Off</span>
+                                            </label>
+                                        </div>
+                                    </td>
+                                </tr>
+                                <tr class="listing-ct-panel credential-panel">
+                                    <td colspan="3">
+                                        <ul class="nav nav-tabs nav-tabs-pf">
+                                            <li class="active"><a href="#" translatable="yes">Details</a></li>
+                                            <li><a href="#" translatable="yes">Public Key</a></li>
+                                            <li><a href="#" translatable="yes">Password</a></li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="listing-ct-body">
+                                    <td colspan="3">
+                                        <div class="alert alert-danger">
+                                            <i class="fa fa-exclamation-triangle"></i>
+                                            <span></span>
+                                        </div>
+                                        <div class="credential-unlock">
+                                            <dl>
+                                                <dt>
+                                                    <label translatable="yes">Password</label>
+                                                </dt>
+                                                <dd>
+                                                    <input class="form-control credential-password"
+                                                            value="" type="password"></input>
+                                                </dd>
+                                                <dt></dt>
+                                                <dd>
+                                                    <button class="btn btn-primary"
+                                                            translate>Unlock Key</button>
+                                                </dd>
+                                            </dl>
+                                        </div>
+                                        <div class="credential-tab credential-panel">
+                                            <dl>
+                                                <dt>
+                                                    <label translate>Comment</label>
+                                                </dt>
+                                                <dd class="credential-comment"></dd>
+                                                <dt>
+                                                    <label translate>Type</label>
+                                                </dt>
+                                                <dd class="credential-type"></dd>
+                                                <dt>
+                                                    <label translate>Fingerprint</label>
+                                                </dt>
+                                                <dd class="credential-fingerprint"></dd>
+                                            </dl>
+                                        </div>
+                                        <div class="credential-tab credential-panel" hidden>
+                                            <textarea class="credential-data form-control" rows="4" readonly>
+                                            </textarea>
+                                        </div>
+                                        <div class="credential-tab credential-panel" hidden>
+                                            <dl>
+                                                <dt>
+                                                    <label translatable="yes">Old Password</label>
+                                                </dt>
+                                                <dd>
+                                                    <input class="form-control credential-old"
                                                         value="" type="password"></input>
-                                            </dd>
-                                            <dt></dt>
-                                            <dd>
-                                                <button class="btn btn-primary"
-                                                        translate>Unlock Key</button>
-                                            </dd>
-                                        </dl>
-                                    </div>
-                                    <div class="credential-tab credential-panel">
-                                        <dl>
-                                            <dt>
-                                                <label translate>Comment</label>
-                                            </dt>
-                                            <dd class="credential-comment"></dd>
-                                            <dt>
-                                                <label translate>Type</label>
-                                            </dt>
-                                            <dd class="credential-type"></dd>
-                                            <dt>
-                                                <label translate>Fingerprint</label>
-                                            </dt>
-                                            <dd class="credential-fingerprint"></dd>
-                                        </dl>
-                                    </div>
-                                    <div class="credential-tab credential-panel" hidden>
-                                        <textarea class="credential-data form-control" rows="4" readonly>
-                                        </textarea>
-                                    </div>
-                                    <div class="credential-tab credential-panel" hidden>
-                                        <dl>
-                                            <dt>
-                                                <label translatable="yes">Old Password</label>
-                                            </dt>
-                                            <dd>
-                                                <input class="form-control credential-old"
-                                                    value="" type="password"></input>
-                                            </dd>
-                                            <dt>
-                                                <label translatable="yes">New Password</label>
-                                            </dt>
-                                            <dd>
-                                                <input class="form-control credential-new"
-                                                    value="" type="password"></input>
-                                            </dd>
-                                            <dt>
-                                                <label translatable="yes">Confirm</label>
-                                            </dt>
-                                            <dd>
-                                                <input class="form-control credential-two"
-                                                    value="" type="password"></input>
-                                            </dd>
-                                            <dt>
-                                                <a tabindex="0" role="button" data-toggle="popover"
-                                                    data-trigger="focus" data-placement="top"
-                                                    data-content="Tip: Make your key password match your login password to automatically authenticate against other systems." translate="data-content">
-                                                    <span class="fa fa-lg fa-info-circle"></span>
-                                                </a>
-                                            </dt>
-                                            <dd>
-                                                <button class="credential-change btn btn-primary"
-                                                    translatable="yes">Change Password</button>
-                                            </dd>
-                                        </dl>
-                                    </div>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </div>
-                <div class="modal-footer">
-                    <button class="btn btn-primary" data-dismiss="modal" translatable="yes">Close</button>
+                                                </dd>
+                                                <dt>
+                                                    <label translatable="yes">New Password</label>
+                                                </dt>
+                                                <dd>
+                                                    <input class="form-control credential-new"
+                                                        value="" type="password"></input>
+                                                </dd>
+                                                <dt>
+                                                    <label translatable="yes">Confirm</label>
+                                                </dt>
+                                                <dd>
+                                                    <input class="form-control credential-two"
+                                                        value="" type="password"></input>
+                                                </dd>
+                                                <dt>
+                                                    <a tabindex="0" role="button" data-toggle="popover"
+                                                        data-trigger="focus" data-placement="top"
+                                                        data-content="Tip: Make your key password match your login password to automatically authenticate against other systems." translate="data-content">
+                                                        <span class="fa fa-lg fa-info-circle"></span>
+                                                    </a>
+                                                </dt>
+                                                <dd>
+                                                    <button class="credential-change btn btn-primary"
+                                                        translatable="yes">Change Password</button>
+                                                </dd>
+                                            </dl>
+                                        </div>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="modal-footer">
+                        <button class="btn btn-primary" data-dismiss="modal" translatable="yes">Close</button>
+                    </div>
                 </div>
             </div>
         </div>
-    </div>
 
-    <div id="sidebar" class="nav-pf-vertical nav-sidebar" hidden>
-        <ul class="list-group machine-color" id="sidebar-menu">
-        </ul>
-        <ul class="list-group machine-color" id="sidebar-tools">
-        </ul>
-    </div>
+        <div class="flex-sidebar">
+            <div class="nav-sidebar-wrap" id="multi-dashboard">
+                <div class="nav-sidebar nav-pf-vertical">
+                    <ul id="main-navbar" class="list-group">
+                        <li id="host-nav-item" class="list-group-item dashboard-link">
+                            <a id="host-nav-link">
+                                <span class="fa pficon-container-node"></span>
+                                <span class="list-group-item-value"></span>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
 
-    <div class="curtains-ct blank-slate-pf" hidden>
-      <div class="blank-slate-pf-icon">
-        <div class="spinner spinner-lg" hidden></div>
-        <i class="fa fa-exclamation-circle"></i>
-      </div>
-      <h1></h1>
-      <p></p>
-      <div class="blank-slate-pf-main-action">
-        <button id="machine-reconnect" class="btn btn-primary btn-lg" translatable="yes">Reconnect</button>
-        <button id="machine-troubleshoot" class="btn btn-primary btn-lg" translatable="yes">Troubleshoot</button>
-      </div>
-    </div>
+            <div id="host-nav" class="nav-pf-secondary-nav">
+                <div id="machine-dropdown" class="nav-item-pf-header">
+                    <a id="machine-link" class="dropdown-toggle" data-toggle="dropdown"
+                        aria-haspopup="true" role="button" aria-expanded="false">
+                      <img src="../shell/images/server-small.png" id="machine-avatar" class="machine-avatar single-dashboard">
+                      <span></span>
+                       <b class="caret"></b>
+                    </a>
 
-    <div id="content">
-      <!-- Initially populate these frames -->
-      <iframe class="container-frame"
-          name="cockpit1:localhost/system" src="../system/index.html#/"></iframe>
+                    <div class="dropdown-menu">
+                        <div class="form-group has-feedback">
+                            <input class="form-control" type="search">
+                            <span class="fa fa-search form-control-feedback"></span>
+                        </div>
+                        <ul role="menu" aria-labelledby="machine-link">
+                        </ul>
+                    </div>
+                </div>
+
+                <div id="host-apps">
+                    <ul class="list-group" id="sidebar-menu">
+                    </ul>
+
+                    <ul class="list-group" id="sidebar-tools">
+                    </ul>
+                </div>
+            </div>
+        </div>
+
+        <div class="curtains-ct blank-slate-pf" hidden>
+          <div class="blank-slate-pf-icon">
+            <div class="spinner spinner-lg" hidden></div>
+            <i class="fa fa-exclamation-circle"></i>
+          </div>
+          <h1></h1>
+          <p></p>
+          <div class="blank-slate-pf-main-action">
+            <button id="machine-reconnect" class="btn btn-primary btn-lg" translatable="yes">Reconnect</button>
+            <button id="machine-troubleshoot" class="btn btn-primary btn-lg" translatable="yes">Troubleshoot</button>
+          </div>
+        </div>
+
+        <div id="content" class="flex-content">
+          <!-- Initially populate these frames -->
+          <iframe class="container-frame"
+              name="cockpit1:localhost/system" src="../system/index.html#/"></iframe>
+        </div>
     </div>
 
     <script src="index.js"></script>

--- a/pkg/shell/index.js
+++ b/pkg/shell/index.js
@@ -32,7 +32,7 @@
 
     credentials.setup();
 
-    /* When Ctrl is held down we display debugging menu items */
+    /* When alt is held down we display debugging menu items */
     document.addEventListener("click", function(ev) {
         var i, visible = !!ev.altKey;
         var advanced = document.querySelectorAll(".navbar-advanced");

--- a/pkg/shell/shell.less
+++ b/pkg/shell/shell.less
@@ -295,16 +295,65 @@ html.index-page body {
     box-shadow: none;
 }
 
-@media (min-width: 320px) and (max-width: 767px) {
-    .navbar-primary .navbar-form {
-    margin: 0;
-    padding: 0;
+.navbar-header .navbar-toggle {
+    display: none;
+}
+
+.navbar-header .navbar-brand {
+    padding: 13px 0 13px 10px;
+}
+
+@media (max-width: 767px) {
+    .navbar-pf-vertical .navbar-toggle {
+        display: block;
+    }
+
+    .navbar-header .navbar-brand {
+        padding: 13px 0 0;
     }
 }
 
 .navbar-default .navbar-form {
     border-color: transparent;
 }
+
+#machine-dropdown {
+    .dropdown-menu {
+        width: unit(@sidebar-width-full, px);
+    }
+
+    #machine-link {
+        color: unset;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    .dropdown-menu:after {
+        border: 10px solid transparent;
+        border-bottom-width: 0;
+        border-top-color: #fff;
+        bottom: -9px;
+        content: '';
+        height: 0;
+        left: 50%;
+        margin: 0 0 0 -10px;
+        position: absolute;
+        width: 0;
+        top:unset;
+    }
+
+    input {
+        padding-left: 25px;
+    }
+
+    i.fa-search {
+        top: 6px;
+        left: 0;
+    }
+}
+
+
 
 .nav > li[hidden] {
     display: none;
@@ -628,6 +677,10 @@ tbody.unlock .credential-unlock {
     padding-right: 5px;
 }
 
+#machine-spinner {
+    margin: 10px;
+}
+
 .spinner-white {
   border-bottom: 4px solid rgba(255, 255, 255, 0.25);
   border-left: 4px solid rgba(255, 255, 255, 0.25);
@@ -649,10 +702,17 @@ tbody.unlock .credential-unlock {
 .navbar-pf .navbar-brand {
     text-transform: uppercase;
     margin: 0 8px;
-    height: 25px;
-    padding: 2px 0;
 }
 
 .navbar-pf .navbar-brand:hover {
     color: #F1F1F1;
+}
+
+.navbar-pf .navbar-utility {
+    font-size: 13px;
+}
+
+.navbar-pf .pficon,
+.navbar-pf .navbar-nav > li > a {
+    line-height: 34px;
 }

--- a/pkg/shell/simple.html
+++ b/pkg/shell/simple.html
@@ -13,126 +13,134 @@
     <script src="../*/po.js"></script>
   </head>
   <body hidden>
-    <nav id="topnav" class="navbar navbar-default navbar-pf" role="navigation">
-      <div class="navbar-header">
-        <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse-1">
-          <i class="fa fa-bars" alt="Toggle navigation"></i>
-        </button>
-        <div class="navbar-brand">
-          <div id="index-brand"></div>
-        </div>
-      </div>
-      <div class="collapse navbar-collapse navbar-collapse-1">
-        <ul class="nav navbar-nav navbar-utility">
-          <li id="navbar-oops" hidden>
-            <a><span class="oops-status" translatable="yes">Ooops!</span></a>
-          </li>
-          <li class="dropdown">
-            <a id="navbar-dropdown" class="dropdown-toggle" data-toggle="dropdown">
-              <span class="pficon pficon-user"></span>
-              <span id="content-user-name"></span><b class="caret"></b>
-            </a>
-            <ul class="dropdown-menu">
-              <li class="display-language-menu">
-                <a data-toggle="modal" data-target="#display-language" translatable="yes">Display Language</a>
+    <div class="flex-container">
+        <nav id="topnav" class="navbar navbar-default navbar-pf navbar-pf-vertical flex-navbar" role="navigation">
+          <div class="navbar-header">
+            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse-1">
+              <i class="fa fa-bars" alt="Toggle navigation"></i>
+            </button>
+            <div class="navbar-brand">
+              <div id="index-brand"></div>
+            </div>
+          </div>
+          <div class="collapse navbar-collapse navbar-collapse-1">
+            <ul class="nav navbar-nav navbar-utility">
+              <li id="navbar-oops" hidden>
+                <a><span class="oops-status" translatable="yes">Ooops!</span></a>
               </li>
-              <li class="divider display-language-menu"></li>
-              <li>
-                <a data-toggle="modal" data-target="#about" translatable="yes">About Cockpit</a>
-              </li>
-              <li class="divider"></li>
-              <li>
-                <a id="go-logout" translatable="yes">Log Out</a>
+              <li class="dropdown">
+                <a id="navbar-dropdown" class="dropdown-toggle" data-toggle="dropdown">
+                  <span class="pficon pficon-user"></span>
+                  <span id="content-user-name"></span><b class="caret"></b>
+                </a>
+                <ul class="dropdown-menu">
+                  <li class="display-language-menu">
+                    <a data-toggle="modal" data-target="#display-language" translatable="yes">Display Language</a>
+                  </li>
+                  <li class="divider display-language-menu"></li>
+                  <li>
+                    <a data-toggle="modal" data-target="#about" translatable="yes">About Cockpit</a>
+                  </li>
+                  <li class="divider"></li>
+                  <li>
+                    <a id="go-logout" translatable="yes">Log Out</a>
+                  </li>
+                </ul>
               </li>
             </ul>
-          </li>
-        </ul>
-        <ul class="nav navbar-nav navbar-primary" id="content-navbar">
-          <li class="dropdown" id="machine-dropdown">
-            <a class="machine-color"></a>
-            <a id="machine-link" class="dropdown-toggle" data-toggle="dropdown"
-                aria-haspopup="true" role="button" aria-expanded="false">
-               <img src="../shell/images/server-small.png" id="machine-avatar"
-                   class="machine-avatar"><span translate>Machines</span>
-               <b class="caret"></b>
-            </a>
-          </li>
-        </ul>
-      </div>
-    </nav>
-
-    <div class="modal" id="about" tabindex="-1" role="dialog" data-backdrop="static">
-      <div class="modal-dialog">
-        <div class="modal-content">
-          <div class="modal-header">
-            <h4 class="modal-title" translatable="yes">About Cockpit</h4>
           </div>
-          <div class="modal-body">
-            <div id="about-desciption" translatable="yes">Cockpit is an interactive Linux server admin interface. </div>
-            <div><a target="_blank" href="http://cockpit-project.org/" translate>Project website</a></div>
-            <div>
-              <span translatable="yes">Version</span> <span id="about-version"></span>.
-            </div>
-            <div><span translate>Licensed under:</span>
-                <a href="https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html"
-                    target="_blank">GNU LGPL version 2.1</a>
+        </nav>
+
+        <div class="modal" id="about" tabindex="-1" role="dialog" data-backdrop="static">
+          <div class="modal-dialog">
+            <div class="modal-content">
+              <div class="modal-header">
+                <h4 class="modal-title" translatable="yes">About Cockpit</h4>
+              </div>
+              <div class="modal-body">
+                <div translatable="yes">Cockpit is an interactive Linux server admin interface.</div>
+                <div><a target="_blank" href="http://cockpit-project.org/" translate>Project website</a></div>
+                <div>
+                  <span translatable="yes">Version</span> <span id="about-version"></span>.
+                </div>
+                <div><span translate>Licensed under:</span>
+                    <a href="https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html"
+                      target="_blank">GNU LGPL version 2.1</a>
+                </div>
+              </div>
+              <div class="modal-footer">
+                <button class="btn btn-primary" data-dismiss="modal" translate>Close</button>
+              </div>
             </div>
           </div>
-          <div class="modal-footer">
-            <button class="btn btn-primary" data-dismiss="modal" translate>Close</button>
+        </div>
+
+        <div class="modal" id="display-language" tabindex="-1" role="dialog" data-backdrop="static">
+          <div class="modal-dialog">
+            <div class="modal-content">
+              <div class="modal-header">
+                <h4 class="modal-title" translatable="yes">Display Language</h4>
+              </div>
+              <div class="modal-body">
+	        <p translatable="yes">Choose the language to be used in the application</p>
+                <select id="display-language-list" size="5" data-role="none">
+                </select>
+              </div>
+              <div class="modal-footer">
+                <button class="btn btn-default" data-dismiss="modal" translatable="yes">Cancel</button>
+                <button class="btn btn-primary" id="display-language-select-button" translatable="yes">Select</button>
+              </div>
+            </div>
           </div>
         </div>
-      </div>
-    </div>
 
-    <div class="modal" id="display-language" tabindex="-1" role="dialog" data-backdrop="static">
-      <div class="modal-dialog">
-        <div class="modal-content">
-          <div class="modal-header">
-            <h4 class="modal-title" translatable="yes">Display Language</h4>
-          </div>
-          <div class="modal-body">
-	    <p translatable="yes">Choose the language to be used in the application</p>
-            <select id="display-language-list" size="5" data-role="none">
-            </select>
-          </div>
-          <div class="modal-footer">
-            <button class="btn btn-default" data-dismiss="modal" translatable="yes">Cancel</button>
-            <button class="btn btn-primary" id="display-language-select-button" translatable="yes">Select</button>
+        <div class="modal" id="disconnected-dialog" tabindex="-1" role="dialog" data-backdrop="static">
+          <div class="modal-dialog">
+            <div class="modal-content">
+              <div class="modal-header">
+                <h4 class="modal-title" translatable="yes">Disconnected</h4>
+              </div>
+              <div class="modal-body">
+                <div id="disconnected-error"></div>
+              </div>
+              <div class="modal-footer">
+                <button class="btn btn-default" id="disconnected-reconnect" translatable="yes">Try to reconnect</button>
+                <button class="btn btn-default" id="disconnected-logout" translatable="yes">Log in again</button>
+              </div>
+            </div>
           </div>
         </div>
-      </div>
-    </div>
 
-    <div class="modal" id="disconnected-dialog" tabindex="-1" role="dialog" data-backdrop="static">
-      <div class="modal-dialog">
-        <div class="modal-content">
-          <div class="modal-header">
-            <h4 class="modal-title" translatable="yes">Disconnected</h4>
+        <div class="flex-sidebar">
+            <div class="nav-sidebar-wrap multi-dashboard">
+                <div class="nav-sidebar nav-pf-vertical">
+                    <ul id="main-navbar" class="list-group">
+                        <li id="host-nav-item" class="list-group-item dashboard-link">
+                            <a id="host-nav-link">
+                                <span class="fa pficon-container-node"></span>
+                                <span class="list-group-item-value"></span>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+
+        <div class="curtains-ct blank-slate-pf" hidden>
+          <div class="blank-slate-pf-icon">
+            <div class="spinner spinner-lg" hidden></div>
+            <i class="fa fa-exclamation-circle"></i>
           </div>
-          <div class="modal-body">
-            <div id="disconnected-error"></div>
-          </div>
-          <div class="modal-footer">
-            <button class="btn btn-default" id="disconnected-reconnect" translatable="yes">Try to reconnect</button>
-            <button class="btn btn-default" id="disconnected-logout" translatable="yes">Log in again</button>
+          <h1></h1>
+          <p></p>
+          <div class="blank-slate-pf-main-action">
+            <button id="machine-reconnect" class="btn btn-primary btn-lg" translatable="yes">Reconnect</button>
+            <button id="machine-troubleshoot" class="btn btn-primary btn-lg" translatable="yes">Troubleshoot</button>
           </div>
         </div>
-      </div>
-    </div>
 
-    <div class="curtains-ct blank-slate-pf" hidden>
-      <div class="blank-slate-pf-icon">
-        <i class="fa fa-exclamation-circle"></i>
-      </div>
-      <h1></h1>
-      <p></p>
-      <div class="blank-slate-pf-main-action">
-        <button id="machine-reconnect" class="btn btn-primary btn-lg" translatable="yes">Reconnect</button>
-      </div>
-    </div>
-
-    <div id="content">
+        <div id="content" class="flex-content">
+        </div>
     </div>
 
     <script src="index-no-machines.js"></script>

--- a/pkg/shell/stub.html
+++ b/pkg/shell/stub.html
@@ -13,147 +13,176 @@
     <script src="../*/po.js"></script>
   </head>
   <body hidden>
-    <nav id="topnav" class="navbar navbar-default navbar-pf" role="navigation">
-      <div class="navbar-header">
-        <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse-1">
-          <i class="fa fa-bars" alt="Toggle navigation"></i>
-        </button>
-        <div class="navbar-brand">
-          <div id="index-brand"></div>
-        </div>
-      </div>
-      <div class="collapse navbar-collapse navbar-collapse-1">
-        <ul class="nav navbar-nav navbar-utility">
-          <li id="navbar-oops" hidden>
-            <a><span class="oops-status" translatable="yes">Ooops!</span></a>
-          </li>
-          <li class="dropdown">
-            <a id="navbar-dropdown" class="dropdown-toggle" data-toggle="dropdown">
-              <span class="pficon pficon-user"></span>
-              <span id="content-user-name"></span><b class="caret"></b>
-            </a>
-            <ul class="dropdown-menu">
-              <li class="display-language-menu">
-                <a data-toggle="modal" data-target="#display-language" translatable="yes">Display Language</a>
+    <div class="flex-container">
+        <nav id="topnav" class="navbar navbar-default navbar-pf navbar-pf-vertical flex-navbar" role="navigation">
+          <div class="navbar-header">
+            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse-1">
+              <i class="fa fa-bars" alt="Toggle navigation"></i>
+            </button>
+            <div class="navbar-brand">
+              <div id="index-brand"></div>
+            </div>
+          </div>
+          <div class="collapse navbar-collapse navbar-collapse-1">
+            <ul class="nav navbar-nav navbar-utility">
+              <li id="machine-spinner">
+                <div class="spinner spinner-md spinner-white">
+                </div>
               </li>
-              <li class="divider display-language-menu"></li>
-              <li>
-                <a data-toggle="modal" data-target="#about" translatable="yes">About Cockpit</a>
+              <li id="navbar-oops" hidden>
+                <a><span class="oops-status" translatable="yes">Ooops!</span></a>
               </li>
-              <li class="divider"></li>
-              <li>
-                <a id="go-logout" translatable="yes">Log Out</a>
+              <li class="dropdown">
+                <a id="navbar-dropdown" class="dropdown-toggle" data-toggle="dropdown">
+                  <span class="pficon pficon-user"></span>
+                  <span id="content-user-name"></span><b class="caret"></b>
+                </a>
+                <ul class="dropdown-menu">
+                  <li class="display-language-menu">
+                    <a data-toggle="modal" data-target="#display-language" translatable="yes">Display Language</a>
+                  </li>
+                  <li class="divider display-language-menu"></li>
+                  <li>
+                    <a data-toggle="modal" data-target="#about" translatable="yes">About Cockpit</a>
+                  </li>
+                  <li>
+                    <a id="active-pages" translatable="yes" class="navbar-advanced">Active Pages</a>
+                  </li>
+                  <li class="divider"></li>
+                  <li>
+                    <a id="go-logout" translatable="yes">Log Out</a>
+                  </li>
+                </ul>
               </li>
             </ul>
-          </li>
-        </ul>
-        <ul class="nav navbar-nav navbar-primary" id="content-navbar">
-          <li id="machine-spinner" hidden>
-            <div class="spinner spinner-md spinner-white">
-            </div>
-          </li>
-          <li class="dropdown" id="machine-dropdown">
-            <a class="machine-color"></a>
-            <a id="machine-link" class="dropdown-toggle" data-toggle="dropdown"
-                aria-haspopup="true" role="button" aria-expanded="false">
-               <img src="../shell/images/server-small.png" id="machine-avatar" class="machine-avatar"><span translate>Machines</span>
-               <b class="caret"></b>
-            </a>
-            <ul class="dropdown-menu" role="menu" aria-labelledby="machine-link">
-            </ul>
-          </li>
-        </ul>
-      </div>
-    </nav>
+          </div>
+        </nav>
 
-    <div class="modal" id="about" tabindex="-1" role="dialog" data-backdrop="static">
-      <div class="modal-dialog">
-        <div class="modal-content">
-          <div class="modal-header">
-            <h4 class="modal-title" translatable="yes">About Cockpit</h4>
-          </div>
-          <div class="modal-body">
-            <div translae>Cockpit is an interactive Linux server admin interface.</div>
-            <div><a target="_blank" href="http://cockpit-project.org/" translate>Project website</a></div>
-            <div>
-              <span translatable="yes">Version</span> <span id="about-version"></span>.
-            </div>
-            <div><span translate>Licensed under:</span>
-                <a href="https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html"
-                    target="_blank">GNU LGPL version 2.1</a>
-            </div>
-          </div>
-          <div class="modal-footer">
-            <button class="btn btn-primary" data-dismiss="modal">Close</button>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <div class="modal" id="troubleshoot-dialog" tabindex="-1" role="dialog"
-        data-backdrop="static">
-        <div class="modal-dialog">
+        <div class="modal" id="about" tabindex="-1" role="dialog" data-backdrop="static">
+          <div class="modal-dialog">
             <div class="modal-content">
+              <div class="modal-header">
+                <h4 class="modal-title" translatable="yes">About Cockpit</h4>
+              </div>
+              <div class="modal-body">
+                <div translatable="yes">Cockpit is an interactive Linux server admin interface.</div>
+                <div><a target="_blank" href="http://cockpit-project.org/" translate>Project website</a></div>
+                <div>
+                  <span translatable="yes">Version</span> <span id="about-version"></span>.
+                </div>
+                <div><span translate>Licensed under:</span>
+                    <a href="https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html"
+                      target="_blank">GNU LGPL version 2.1</a>
+                </div>
+              </div>
+              <div class="modal-footer">
+                <button class="btn btn-primary" data-dismiss="modal" translate>Close</button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="modal" id="troubleshoot-dialog" tabindex="-1" role="dialog"
+            data-backdrop="static">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                </div>
             </div>
         </div>
-    </div>
 
-    <div class="modal" id="display-language" tabindex="-1" role="dialog" data-backdrop="static">
-      <div class="modal-dialog">
-        <div class="modal-content">
-          <div class="modal-header">
-            <h4 class="modal-title" translatable="yes">Display Language</h4>
-          </div>
-          <div class="modal-body">
-	    <p translatable="yes">Choose the language to be used in the application</p>
-            <select id="display-language-list" size="5" data-role="none">
-            </select>
-          </div>
-          <div class="modal-footer">
-            <button class="btn btn-default" data-dismiss="modal" translate>Cancel</button>
-            <button class="btn btn-primary" id="display-language-select-button" translate>Select</button>
+        <div class="modal" id="display-language" tabindex="-1" role="dialog" data-backdrop="static">
+          <div class="modal-dialog">
+            <div class="modal-content">
+              <div class="modal-header">
+                <h4 class="modal-title" translatable="yes">Display Language</h4>
+              </div>
+              <div class="modal-body">
+	        <p translatable="yes">Choose the language to be used in the application</p>
+                <select id="display-language-list" size="5" data-role="none">
+                </select>
+              </div>
+              <div class="modal-footer">
+                <button class="btn btn-default" data-dismiss="modal" translatable="yes">Cancel</button>
+                <button class="btn btn-primary" id="display-language-select-button" translatable="yes">Select</button>
+              </div>
+            </div>
           </div>
         </div>
-      </div>
-    </div>
 
-    <div class="modal" id="error-popup" tabindex="-1" role="dialog" data-backdrop="static">
-      <div class="modal-dialog">
-        <div class="modal-content">
-          <div class="modal-header">
-            <h4 class="modal-title" id="error-popup-title"></h4>
-          </div>
-          <div class="modal-body">
-            <p id="error-popup-message"></p>
-          </div>
-          <div class="modal-footer">
-            <button class="btn btn-primary" data-dismiss="modal" translate>Close</button>
+        <div class="modal" id="error-popup" tabindex="-1" role="dialog" data-backdrop="static">
+          <div class="modal-dialog">
+            <div class="modal-content">
+              <div class="modal-header">
+                <h4 class="modal-title" id="error-popup-title"></h4>
+              </div>
+              <div class="modal-body">
+                <p id="error-popup-message"></p>
+              </div>
+              <div class="modal-footer">
+                <button class="btn btn-primary" data-dismiss="modal" translatable="yes">Close</button>
+              </div>
+            </div>
           </div>
         </div>
-      </div>
-    </div>
 
-    <div id="sidebar" class="sidebar-pf sidebar-pf-left" hidden>
-        <ul class="list-group" id="sidebar-menu">
-        </ul>
-        <ul class="list-group" id="sidebar-tools">
-        </ul>
-    </div>
+        <div class="flex-sidebar">
+            <div class="nav-sidebar-wrap" id="multi-dashboard">
+                <div class="nav-sidebar nav-pf-vertical">
+                    <ul id="main-navbar" class="list-group">
+                        <li id="host-nav-item" class="list-group-item dashboard-link">
+                            <a id="host-nav-link">
+                                <span class="fa pficon-container-node"></span>
+                                <span class="list-group-item-value"></span>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
 
-    <div class="curtains-ct blank-slate-pf" hidden>
-      <div class="blank-slate-pf-icon">
-        <div class="spinner spinner-lg" hidden></div>
-        <i class="fa fa-exclamation-circle"></i>
-      </div>
-      <h1></h1>
-      <p></p>
-      <div class="blank-slate-pf-main-action">
-        <button id="machine-reconnect" class="btn btn-primary btn-lg" translatable="yes">Reconnect</button>
-        <button id="machine-troubleshoot" class="btn btn-primary btn-lg" translatable="yes">Troubleshoot</button>
-      </div>
-    </div>
+            <div id="host-nav" class="nav-pf-secondary-nav">
+                <div id="machine-dropdown" class="nav-item-pf-header">
+                    <a id="machine-link" class="dropdown-toggle" data-toggle="dropdown"
+                        aria-haspopup="true" role="button" aria-expanded="false">
+                      <img src="../shell/images/server-small.png" id="machine-avatar" class="machine-avatar single-dashboard">
+                      <span></span>
+                       <b class="caret"></b>
+                    </a>
 
-    <div id="content">
+                    <div class="dropdown-menu">
+                        <div class="form-group has-feedback">
+                            <input class="form-control" type="search">
+                            <span class="fa fa-search form-control-feedback"></span>
+                        </div>
+                        <ul role="menu" aria-labelledby="machine-link">
+                        </ul>
+                    </div>
+                </div>
+
+                <div id="host-apps">
+                    <ul class="list-group" id="sidebar-menu">
+                    </ul>
+
+                    <ul class="list-group" id="sidebar-tools">
+                    </ul>
+                </div>
+            </div>
+        </div>
+
+        <div class="curtains-ct blank-slate-pf" hidden>
+          <div class="blank-slate-pf-icon">
+            <div class="spinner spinner-lg" hidden></div>
+            <i class="fa fa-exclamation-circle"></i>
+          </div>
+          <h1></h1>
+          <p></p>
+          <div class="blank-slate-pf-main-action">
+            <button id="machine-reconnect" class="btn btn-primary btn-lg" translatable="yes">Reconnect</button>
+            <button id="machine-troubleshoot" class="btn btn-primary btn-lg" translatable="yes">Troubleshoot</button>
+          </div>
+        </div>
+
+        <div id="content" class="flex-content">
+        </div>
     </div>
 
     <script src="index-stub.js"></script>

--- a/pkg/shell/switcher.less
+++ b/pkg/shell/switcher.less
@@ -19,7 +19,6 @@
 
 .flex-sidebar {
     flex: none;
-    height: 100%;
     z-index: 999;
 }
 

--- a/pkg/shell/switcher.less
+++ b/pkg/shell/switcher.less
@@ -1,150 +1,166 @@
-.nav-sidebar {
-    float: left;
-    width: unit(@sidebar-width-md, px);
-    background-color: #1d1d1d;
-    z-index: 1;
-    position: relative;
-    top: 0px;
-    overflow-x: hidden;
-    overflow-y: auto;
-
-    a {
-        padding: 4px 8px !important;
-        height: 30px !important;
-        width: unit(@sidebar-width-md, px) !important;
-    }
-
-    span {
-        display: block;
-        font-size: 12px;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        margin-left: 7px;
-    }
-
-    .list-group {
-        background-color: #292e34;
-
-        .list-group-item {
-            border-color: transparent;
-        }
-
-        .list-group-item.active {
-            a::before {
-                display: none;
-            }
-        }
-    }
-
-    .list-group + .list-group {
-        padding-top: 15px !important;
-    }
-
-    .list-group-item-value {
-        max-width: unit(@sidebar-width-xl - 80, px) !important;
-    }
-}
-
-.navbar-default .navbar-form {
-    border-color: transparent;
-}
-
 #content {
     position: relative;
 }
 
-.machine-color {
-    /* Width overridden elsewhere */
-    border-left: 0px solid #BABABA;
-    border-top: none !important;
-    border-bottom: none !important;
-    padding: 0px !important;
+.flex-navbar {
+    min-width: 100%;
 }
 
-#machine-dropdown {
-    .machine-color {
-        float: left;
-    }
-
-    a {
-        font-size: 13px;
-    }
-
-    .dropdown-menu {
-        width: 100%;
-        border-left: none;
-
-        a {
-            padding: 10px;
-        }
-
-        li {
-            border-left: 7px solid #BABABA;
-
-            a {
-                max-width: 201px;
-                text-overflow: ellipsis;
-                overflow: hidden;
-            }
-        }
-    }
+.flex-content {
+    flex: 1;
 }
 
-#machine-link {
-    padding: 9px;
-    padding-left: 12px;
-    padding-right: 15px;
-    position: static;
-    min-width: 179px;
 
-    span {
-        display: inline-block;
-        width: 100px;
-        text-overflow: ellipsis;
-        overflow: hidden;
-        white-space: nowrap;
-        vertical-align: middle;
-    }
+.flex-sidebar:hover {}
+
+.flex-sidebar {
+    position: relative;
 }
 
-.machine-avatar {
-    width: 24px;
-    height: 24px;
-    margin-right: 5px;
+.flex-sidebar {
+    flex: 0;
+    height: 100%;
+    z-index: 999;
+}
+
+.nav-pf-vertical {
+    position: static !important;
+    height: 100%;
+    border-right-width: 0;
+}
+
+.nav-sidebar-wrap:not(.expanded) {
+    width: unit(@sidebar-width-sm, px);
+}
+
+.nav-sidebar .fa {
+    margin-left: -4px;
+    margin-top: -1px;
+}
+
+.nav-sidebar span.first-letter {
+    font-size: 0px !important;
+    color: #d1d1d1;
+}
+
+.nav-sidebar span.first-letter:first-letter {
+    font-size: 22px !important;
+}
+
+.nav-sidebar .fa:not(.first-letter) {
+    font-size: 22px !important;
+}
+
+.nav-sidebar {
+    transition: all 150ms ease-out;
+    box-shadow: 0 0;
+}
+
+.nav-sidebar-wrap:not(.expanded) .nav-sidebar {
+    width: unit(@sidebar-width-sm, px);
+}
+
+.nav-sidebar .list-group-item {
+    border-right-width: 0;
+    overflow: hidden;
+}
+
+.nav-sidebar-wrap:not(.expanded) .list-group-item-value {
+    opacity: 0;
+    transition: opacity 150ms ease-out;
+}
+
+.nav-sidebar:focus {
+    background: active;
+}
+
+.nav-sidebar {
+    height: 100vh;
+}
+
+.nav-sidebar-wrap:not(.expanded) .nav-sidebar:not(.clicked):hover {
+    width: unit(@sidebar-width-full, px);
+    box-shadow: 0 0 3px rgba(0,0,0,0.5), 0 0 32px rgba(0,0,0,0.75);
+    transition-duration: 500ms;
+    transition-timing-function: cubic-bezier(0,1.2,0.8,1);
+}
+
+.nav-sidebar-wrap:not(.expanded) .nav-sidebar:not(.clicked):hover .list-group-item-value {
+    transition-duration: 300ms;
+    opacity: 1;
+}
+
+.nav-sidebar:not(.clicked):hover .first-letter {
+    opacity: 0;
+}
+
+.single-nav .nav-sidebar {
     display: none;
 }
 
-#machine-spinner {
-    float: right;
-    margin: 8px;
+.single-nav .nav-sidebar-wrap {
+    width: 0px;
 }
 
-@media (min-width: @screen-sm-min) {
-    #machine-dropdown {
-        .machine-color {
-            height: 44px !important;
-        }
-    }
+.single-nav .nav-pf-secondary-nav {
+    left: 0px;
+}
 
-    .nav-sidebar {
-        width: unit(@sidebar-width-xl, px);
+.nav-pf-secondary-nav {
+    left: unit(@sidebar-width-sm, px);
+    background: #393f44;
+    border-right: 1px solid #292e34;
+    border-bottom: none;
+    border-top: none;
+    border-left: none;
+    bottom: 0;
+    overflow-x: hidden;
+    overflow-y: auto;
+    position: fixed;
+    top: 49px;
+    width: 200px;
+    z-index: -1;
+}
 
-        a {
-            padding: 4px 8px !important;
-            height: 30px !important;
-            width: unit(@sidebar-width-xl, px) !important;
-        }
+.nav-item-pf-header {
+	color: #fff;
+	font-size: 16px;
+    margin: 18px 20px 10px 20px;
+}
 
-        span {
-            margin-left: 26px;
-        }
-    }
+.nav-pf-secondary-nav .list-group {
+    border: none;
+}
 
-    .machine-color {
-        border-left-width: 7px;
-    }
+.nav-pf-secondary-nav .list-group-item {
+    background: inherit;
+    border: none;
+}
 
-    .machine-avatar {
-        display: inline;
-    }
+.nav-pf-secondary-nav .list-group-item.active {
+    background: #4d5258;
+}
+
+.nav-pf-secondary-nav .list-group-item a {
+    display: block;
+    color: #d1d1d1;
+}
+
+#host-nav-item {
+    display: none;
+}
+
+#host-nav-item.dashboard-link {
+    display: block
+}
+
+.flex-container {
+    display: flex;
+    width: 100%;
+    height: 100%;
+    flex-flow: row wrap;
+}
+
+.flex-content {
+    flex: 1;
 }

--- a/pkg/shell/switcher.less
+++ b/pkg/shell/switcher.less
@@ -7,7 +7,7 @@
 }
 
 .flex-content {
-    flex: 1;
+    flex: auto;
 }
 
 
@@ -18,7 +18,7 @@
 }
 
 .flex-sidebar {
-    flex: 0;
+    flex: none;
     height: 100%;
     z-index: 999;
 }
@@ -162,5 +162,5 @@
 }
 
 .flex-content {
-    flex: 1;
+    flex: auto;
 }

--- a/pkg/shell/variables.less
+++ b/pkg/shell/variables.less
@@ -1,4 +1,4 @@
 @import "/variables.less";
 
-@sidebar-width-xl: 180;
-@sidebar-width-md: 120;
+@sidebar-width-full: 180;
+@sidebar-width-sm: 68;


### PR DESCRIPTION
These changes seem to better support `.single-nav` when testing with `$('.flex-sidebar').toggleClass("single-nav");` locally.

`flex: 1` is not quite `flex: auto` and `flex: 0` is not quite `flex: none` — in most cases, auto, none, and initial (default) are what people actually want.

(Sorry I set it to 1 and 0 initially instead of auto and none. They're almost interchangeable in most circumstances, but not quite.)

https://developer.mozilla.org/en-US/docs/Web/CSS/flex?v=example

The big issue was `height: 100%` on the sidebar, which confused things and shoved the content below the page.